### PR TITLE
Bump to 0.0.7. Update to work towards GitHub releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.0.6</upstream.version>
-        <upstream.url>https://raw.githubusercontent.com/pablojim/highcharts-ng/${upstream.version}/dist</upstream.url>
+        <upstream.version>0.0.7</upstream.version>
+        <upstream.url>http://github.com/pablojim/highcharts-ng/archive</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
         <requirejs>
             {
@@ -84,20 +84,29 @@
                         </goals>
                         <configuration>
                             <url>${upstream.url}</url>
-                            <fromFile>highcharts-ng.js</fromFile>
-                            <toDir>${destDir}</toDir>
+                            <fromFile>${upstream.version}.zip</fromFile>
+                            <toFile>${project.build.directory}/${project.artifactId}.zip</toFile>
                         </configuration>
                     </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
                     <execution>
-                        <id>download-min-js</id>
                         <phase>process-resources</phase>
-                        <goals>
-                            <goal>download-single</goal>
-                        </goals>
+                        <goals><goal>run</goal></goals>
                         <configuration>
-                            <url>${upstream.url}</url>
-                            <fromFile>highcharts-ng.min.js</fromFile>
-                            <toDir>${destDir}</toDir>
+                            <target>
+                                <echo message="unzip archive" />
+                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
+                                <echo message="moving resources" />
+                                <move todir="${destDir}">
+                                    <fileset dir="${project.build.directory}/highcharts-ng-${upstream.version}/dist" />
+                                </move>
+                            </target>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
0.0.7 version bump

Also changing to download files from https://github.com/pablojim/highcharts-ng/releases instead of raw content
Downloading logic is based on https://github.com/webjars/angular-ui-select/blob/master/pom.xml but packaging remains the same
